### PR TITLE
Fix incorrect spawner entity IDs

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -13,7 +13,7 @@ from converter import entity as Entity
 from converter import tileEntity as TileEntity
 from converter import util as Util
 
-VERSION = "1.2.3"
+VERSION = "1.2.4"
 
 def save_chunk(region, chunk):
     region.write_chunk(chunk.x, chunk.z, chunk)

--- a/converter/tileEntity.py
+++ b/converter/tileEntity.py
@@ -81,7 +81,7 @@ def convert_spawner(spawner):
     spawner["id"].value = "MobSpawner"
     spawner["Delay"].value = 0
     if spawner["SpawnData"].__contains__("id"):
-        entity_type = Util.minecraft_to_name(spawner["SpawnData"]["id"].value)
+        entity_type = Util.convert_entity_id(spawner["SpawnData"]["id"].value)
     else:
         entity_type = "Pig"
     # convert entity for next spawn

--- a/converter/util.py
+++ b/converter/util.py
@@ -144,3 +144,20 @@ def potion_name_to_numeric(p, splash = False):
 
 def bin_add(*args):
     return bin(sum(int(x, 2) for x in args))[2:]
+
+def convert_entity_id(entity):
+    # legacy IDs which are different to the minecraft ID
+    legacy = {
+        "minecraft:falling_block": "FallingSand",
+        "minecraft:potion": "ThrownPotion",
+        "minecraft:zombie_pigman": "PigZombie",
+        "minecraft:tnt": "PrimedTnt"
+    }
+    # see if there is a legacy ID available
+    # else try an automatic conversion
+    if entity in legacy:
+        new_id = legacy[entity]
+    else:
+        new_id = minecraft_to_name(entity)
+    
+    return new_id


### PR DESCRIPTION
IDs such as `minecraft:potion` were previously converted to `Potion`, which is incorrect. This is now correctly converted to `ThrownPotion`, and the same goes for a few other entities that may be required. This doesn't cover all cases, but can easily be expanded to do so when required.