### PR TITLE
fix: discard data version when the chunk is converted

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -16,6 +16,9 @@ from converter import util as Util
 VERSION = "1.3.2"
 
 def save_chunk(region, chunk):
+    # Discard data version to avoid issues when upgrading the world back
+    if chunk.__contains__("DataVersion") and chunk["DataVersion"].value != 0:
+        chunk["DataVersion"].value = 0
     region.write_chunk(chunk.x, chunk.z, chunk)
 
 def save_level(level, world_folder):


### PR DESCRIPTION
Having a data version on the chunks makes Minecraft servers running modern versions incorrectly believe they're upgrading a newer chunk although the data inside it is for 1.8, resulting in chunk load failures in modern Minecraft (ranging from missing tile entities to the converted chunk not loading at all).